### PR TITLE
Run test cases on Travis CI and upload to PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+matrix:
+  include:
+    - os: linux
+      env: SCRIPT=ubuntu WITH_CORE_LIBRARY=yes
+      services: docker
+    - os: linux
+      env: SCRIPT=ubuntu
+      services: docker
+    - os: linux
+      env: SCRIPT=debian WITH_CORE_LIBRARY=yes
+      services: docker
+    - os: linux
+      env: SCRIPT=debian
+      services: docker
+    - os: linux
+      env: SCRIPT=fedora WITH_CORE_LIBRARY=yes
+      services: docker
+    - os: linux
+      env: SCRIPT=fedora
+      services: docker
+    - os: osx
+      env: SCRIPT=osx WITH_CORE_LIBRARY=yes
+    - os: osx
+      env: SCRIPT=osx
+
+script:
+  - $TRAVIS_BUILD_DIR/.travis/${SCRIPT}.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-language: python
-python: 3.5
-
 stages:
   - test
   - deploy
@@ -40,6 +37,8 @@ matrix:
     - if: branch = develop
       stage: deploy
       os: linux
+      language: python
+      python: 3.5
       script:
         - export PRIMITIV_PYTHON_BUILD_NUMBER="dev${TRAVIS_BUILD_NUMBER}";
         - pip install cython numpy scikit-build twine
@@ -54,6 +53,8 @@ matrix:
     - if: branch = master
       stage: deploy
       os: linux
+      language: python
+      python: 3.5
       script:
         - export PRIMITIV_PYTHON_BUILD_NUMBER="${TRAVIS_BUILD_NUMBER}";
         - pip install cython numpy scikit-build twine

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,70 @@
+language: python
+python: 3.5
+
+stages:
+  - test
+  - deploy
+
 matrix:
   include:
-    - os: linux
+    - stage: test
+      os: linux
       env: SCRIPT=ubuntu WITH_CORE_LIBRARY=yes
       services: docker
-    - os: linux
+    - stage: test
+      os: linux
       env: SCRIPT=ubuntu
       services: docker
-    - os: linux
+    - stage: test
+      os: linux
       env: SCRIPT=debian WITH_CORE_LIBRARY=yes
       services: docker
-    - os: linux
+    - stage: test
+      os: linux
       env: SCRIPT=debian
       services: docker
-    - os: linux
+    - stage: test
+      os: linux
       env: SCRIPT=fedora WITH_CORE_LIBRARY=yes
       services: docker
-    - os: linux
+    - stage: test
+      os: linux
       env: SCRIPT=fedora
       services: docker
-    - os: osx
+    - stage: test
+      os: osx
       env: SCRIPT=osx WITH_CORE_LIBRARY=yes
-    - os: osx
+    - stage: test
+      os: osx
       env: SCRIPT=osx
+    - if: branch = develop
+      stage: deploy
+      os: linux
+      script:
+        - export PRIMITIV_PYTHON_BUILD_NUMBER="dev${TRAVIS_BUILD_NUMBER}";
+        - pip install cython numpy scikit-build twine
+        - $TRAVIS_BUILD_DIR/setup.py sdist --bundle-core-library
+      deploy:
+        skip_cleanup: true
+        provider: script
+        script: twine upload -u $PYPI_USERNAME -p $PYPI_PASSWORD $TRAVIS_BUILD_DIR/dist/*.tar.gz
+        on:
+          tags: false
+          branch: develop
+    - if: branch = master
+      stage: deploy
+      os: linux
+      script:
+        - export PRIMITIV_PYTHON_BUILD_NUMBER="${TRAVIS_BUILD_NUMBER}";
+        - pip install cython numpy scikit-build twine
+        - $TRAVIS_BUILD_DIR/setup.py sdist --bundle-core-library
+      deploy:
+        skip_cleanup: true
+        provider: script
+        script: twine upload -u $PYPI_USERNAME -p $PYPI_PASSWORD $TRAVIS_BUILD_DIR/dist/*.tar.gz
+        on:
+          tags: false
+          branch: master
 
 script:
   - $TRAVIS_BUILD_DIR/.travis/${SCRIPT}.sh

--- a/.travis/debian.sh
+++ b/.travis/debian.sh
@@ -27,11 +27,11 @@ if [ "${WITH_CORE_LIBRARY}" = "yes" ]; then
     # test installing by "pip install"
     docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py sdist --bundle-core-library"
 
-    docker exec travis-ci bash -c "pip3 install /primitiv-python/dist/primitiv-*.tar.gz --verbose"
+    docker exec travis-ci bash -c "pip3 install /primitiv-python/dist/primitiv-*.tar.gz --verbose --global-option --enable-opencl"
     docker exec travis-ci bash -c "python3 -c 'import primitiv; dev = primitiv.devices.Naive()'"
     docker exec travis-ci bash -c "pip3 uninstall -y primitiv"
 
-    docker exec travis-ci bash -c "pip3 install --user /primitiv-python/dist/primitiv-*.tar.gz --verbose"
+    docker exec travis-ci bash -c "pip3 install --user /primitiv-python/dist/primitiv-*.tar.gz --verbose --global-option --enable-opencl"
     docker exec travis-ci bash -c "python3 -c 'import primitiv; dev = primitiv.devices.Naive()'"
     docker exec travis-ci bash -c "pip3 uninstall -y primitiv"
 else

--- a/.travis/debian.sh
+++ b/.travis/debian.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -xe
+
+# before_install
+docker pull debian:stable
+docker run --name travis-ci -v $TRAVIS_BUILD_DIR:/primitiv-python -td debian:stable /bin/bash
+
+# install
+docker exec travis-ci bash -c "apt update"
+docker exec travis-ci bash -c "apt install -y git build-essential cmake python3-dev python3-pip python3-numpy"
+docker exec travis-ci bash -c "pip3 install cython scikit-build"
+
+# install OpenCL environment
+docker exec travis-ci bash -c "apt install -y opencl-headers libclblas-dev pkg-config libhwloc-dev libltdl-dev ocl-icd-dev ocl-icd-opencl-dev clang-3.8 llvm-3.8-dev libclang-3.8-dev libz-dev"
+# pocl 0.13 does not contain mem_fence() function that is used by primitiv.
+# We build the latest pocl instead of using distribution's package.
+# See: https://github.com/pocl/pocl/issues/294
+docker exec travis-ci bash -c "git clone https://github.com/pocl/pocl.git"
+docker exec travis-ci bash -c "cd ./pocl && cmake . -DCMAKE_INSTALL_PREFIX=/usr"
+docker exec travis-ci bash -c "cd ./pocl && make && make install"
+
+if [ "${WITH_CORE_LIBRARY}" = "yes" ]; then
+    # script
+    docker exec travis-ci bash -c "cd /primitiv-python && git submodule update --init"
+    docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py build --enable-opencl && ./setup.py test"
+
+    # test installing by "pip install"
+    docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py sdist --bundle-core-library"
+
+    docker exec travis-ci bash -c "pip3 install /primitiv-python/dist/primitiv-*.tar.gz --verbose"
+    docker exec travis-ci bash -c "python3 -c 'import primitiv; dev = primitiv.devices.Naive()'"
+    docker exec travis-ci bash -c "pip3 uninstall -y primitiv"
+
+    docker exec travis-ci bash -c "pip3 install --user /primitiv-python/dist/primitiv-*.tar.gz --verbose"
+    docker exec travis-ci bash -c "python3 -c 'import primitiv; dev = primitiv.devices.Naive()'"
+    docker exec travis-ci bash -c "pip3 uninstall -y primitiv"
+else
+    # install core library
+    docker exec travis-ci bash -c "git clone https://github.com/primitiv/primitiv.git libprimitiv"
+    docker exec travis-ci bash -c "cd ./libprimitiv && cmake . -DPRIMITIV_USE_OPENCL=ON"
+    docker exec travis-ci bash -c "cd ./libprimitiv && make && make install"
+    docker exec travis-ci bash -c "ldconfig"
+
+    # script
+    docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py build --enable-opencl && ./setup.py test"
+fi
+
+# test installing by "./setup.py install"
+docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py install --enable-opencl"
+docker exec travis-ci bash -c "python3 -c 'import primitiv; dev = primitiv.devices.Naive()'"
+docker exec travis-ci bash -c "pip3 uninstall -y primitiv"
+
+# after_script
+docker stop travis-ci

--- a/.travis/fedora.sh
+++ b/.travis/fedora.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -xe
+
+# before_install
+docker pull fedora:latest
+docker run --name travis-ci -v $TRAVIS_BUILD_DIR:/primitiv-python -td fedora:latest /bin/bash
+
+# install
+docker exec travis-ci bash -c "dnf update -y"
+docker exec travis-ci bash -c "dnf install -y git rpm-build gcc-c++ cmake python3-devel python3-numpy"
+docker exec travis-ci bash -c "pip3 install cython scikit-build"
+
+# install OpenCL environment
+docker exec travis-ci bash -c "dnf install -y opencl-headers hwloc-devel libtool-ltdl-devel ocl-icd-devel ocl-icd clang llvm-devel clang-devel zlib-devel blas-devel boost-devel patch --setopt=install_weak_deps=False"
+docker exec travis-ci bash -c "git clone https://github.com/clMathLibraries/clBLAS.git"
+docker exec travis-ci bash -c "cd ./clBLAS/src && cmake . -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_TEST=OFF -DBUILD_KTEST=OFF"
+docker exec travis-ci bash -c "cd ./clBLAS/src && make && make install"
+# pocl 0.13 does not contain mem_fence() function that is used by primitiv.
+# We build the latest pocl instead of using distribution's package.
+# See: https://github.com/pocl/pocl/issues/294
+docker exec travis-ci bash -c "git clone https://github.com/pocl/pocl.git"
+docker exec travis-ci bash -c "cd ./pocl && cmake . -DCMAKE_INSTALL_PREFIX=/usr"
+docker exec travis-ci bash -c "cd ./pocl && make && make install"
+
+if [ "${WITH_CORE_LIBRARY}" = "yes" ]; then
+    # script
+    docker exec travis-ci bash -c "cd /primitiv-python && git submodule update --init"
+    docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py build --enable-opencl && ./setup.py test"
+
+    # test installing by "pip install"
+    docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py sdist --bundle-core-library"
+
+    docker exec travis-ci bash -c "pip3 install --user /primitiv-python/dist/primitiv-*.tar.gz --verbose"
+    docker exec travis-ci bash -c "python3 -c 'import primitiv; dev = primitiv.devices.Naive()'"
+    docker exec travis-ci bash -c "pip3 uninstall -y primitiv"
+else
+    # install core library
+    docker exec travis-ci bash -c "git clone https://github.com/primitiv/primitiv.git libprimitiv"
+    docker exec travis-ci bash -c "cd ./libprimitiv && cmake . -DPRIMITIV_USE_OPENCL=ON"
+    docker exec travis-ci bash -c "cd ./libprimitiv && make && make install"
+
+    # script
+    docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py build --enable-opencl && ./setup.py test"
+fi
+
+# test installing by "./setup.py install"
+docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py install --enable-opencl"
+docker exec travis-ci bash -c "python3 -c 'import primitiv; dev = primitiv.devices.Naive()'"
+docker exec travis-ci bash -c "pip3 uninstall -y primitiv"
+
+# after_script
+docker stop travis-ci

--- a/.travis/fedora.sh
+++ b/.travis/fedora.sh
@@ -30,7 +30,7 @@ if [ "${WITH_CORE_LIBRARY}" = "yes" ]; then
     # test installing by "pip install"
     docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py sdist --bundle-core-library"
 
-    docker exec travis-ci bash -c "pip3 install --user /primitiv-python/dist/primitiv-*.tar.gz --verbose"
+    docker exec travis-ci bash -c "pip3 install --user /primitiv-python/dist/primitiv-*.tar.gz --verbose --global-option --enable-opencl"
     docker exec travis-ci bash -c "python3 -c 'import primitiv; dev = primitiv.devices.Naive()'"
     docker exec travis-ci bash -c "pip3 uninstall -y primitiv"
 else

--- a/.travis/osx.sh
+++ b/.travis/osx.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -xe
+
+# install
+brew update
+brew install python3
+pip3 install cython numpy scikit-build
+
+pushd $TRAVIS_BUILD_DIR
+
+mkdir work
+
+if [ "${WITH_CORE_LIBRARY}" = "yes" ]; then
+    # script
+    git submodule update --init
+    ./setup.py build && ./setup.py test
+
+    # test installing by "pip install"
+    ./setup.py sdist --bundle-core-library
+
+    pip3 install dist/primitiv-*.tar.gz --verbose
+    pushd work
+    python3 -c 'import primitiv; dev = primitiv.devices.Naive()'
+    popd
+    pip3 uninstall -y primitiv
+
+    pip3 install --user dist/primitiv-*.tar.gz --verbose
+    pushd work
+    python3 -c 'import primitiv; dev = primitiv.devices.Naive()'
+    popd
+    pip3 uninstall -y primitiv
+else
+    git clone https://github.com/primitiv/primitiv.git libprimitiv
+    pushd libprimitiv
+    cmake .
+    make && make install
+    popd
+    ./setup.py build && ./setup.py test
+fi
+
+# test installing by "./setup.py install"
+./setup.py install
+pushd work
+python3 -c 'import primitiv; dev = primitiv.devices.Naive()'
+popd
+pip3 uninstall -y primitiv

--- a/.travis/ubuntu.sh
+++ b/.travis/ubuntu.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -xe
+
+# before_install
+docker pull ubuntu:rolling
+docker run --name travis-ci -v $TRAVIS_BUILD_DIR:/primitiv-python -td ubuntu:rolling /bin/bash
+
+# install
+docker exec travis-ci bash -c "apt update"
+docker exec travis-ci bash -c "apt install -y git build-essential cmake python3-dev python3-pip python3-numpy"
+docker exec travis-ci bash -c "pip3 install cython scikit-build"
+
+# install OpenCL environment
+docker exec travis-ci bash -c "apt install -y opencl-headers libclblas-dev pkg-config libhwloc-dev libltdl-dev ocl-icd-dev ocl-icd-opencl-dev clang-3.8 llvm-3.8-dev libclang-3.8-dev libz-dev"
+# pocl 0.13 does not contain mem_fence() function that is used by primitiv.
+# We build the latest pocl instead of using distribution's package.
+# See: https://github.com/pocl/pocl/issues/294
+docker exec travis-ci bash -c "git clone https://github.com/pocl/pocl.git"
+docker exec travis-ci bash -c "cd ./pocl && cmake . -DCMAKE_INSTALL_PREFIX=/usr"
+docker exec travis-ci bash -c "cd ./pocl && make && make install"
+
+if [ "${WITH_CORE_LIBRARY}" = "yes" ]; then
+    # script
+    docker exec travis-ci bash -c "cd /primitiv-python && git submodule update --init"
+    docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py build --enable-opencl && ./setup.py test"
+
+    # test installing by "pip install"
+    docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py sdist --bundle-core-library"
+
+    docker exec travis-ci bash -c "pip3 install /primitiv-python/dist/primitiv-*.tar.gz --verbose"
+    docker exec travis-ci bash -c "python3 -c 'import primitiv; dev = primitiv.devices.Naive()'"
+    docker exec travis-ci bash -c "pip3 uninstall -y primitiv"
+
+    docker exec travis-ci bash -c "pip3 install --user /primitiv-python/dist/primitiv-*.tar.gz --verbose"
+    docker exec travis-ci bash -c "python3 -c 'import primitiv; dev = primitiv.devices.Naive()'"
+    docker exec travis-ci bash -c "pip3 uninstall -y primitiv"
+else
+    # install core library
+    docker exec travis-ci bash -c "git clone https://github.com/primitiv/primitiv.git libprimitiv"
+    docker exec travis-ci bash -c "cd ./libprimitiv && cmake . -DPRIMITIV_USE_OPENCL=ON"
+    docker exec travis-ci bash -c "cd ./libprimitiv && make && make install"
+    docker exec travis-ci bash -c "ldconfig"
+
+    # script
+    docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py build --enable-opencl && ./setup.py test"
+fi
+
+# test installing by "./setup.py install"
+docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py install --enable-opencl"
+docker exec travis-ci bash -c "python3 -c 'import primitiv; dev = primitiv.devices.Naive()'"
+docker exec travis-ci bash -c "pip3 uninstall -y primitiv"
+
+# after_script
+docker stop travis-ci

--- a/.travis/ubuntu.sh
+++ b/.travis/ubuntu.sh
@@ -27,11 +27,11 @@ if [ "${WITH_CORE_LIBRARY}" = "yes" ]; then
     # test installing by "pip install"
     docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py sdist --bundle-core-library"
 
-    docker exec travis-ci bash -c "pip3 install /primitiv-python/dist/primitiv-*.tar.gz --verbose"
+    docker exec travis-ci bash -c "pip3 install /primitiv-python/dist/primitiv-*.tar.gz --verbose --global-option --enable-opencl"
     docker exec travis-ci bash -c "python3 -c 'import primitiv; dev = primitiv.devices.Naive()'"
     docker exec travis-ci bash -c "pip3 uninstall -y primitiv"
 
-    docker exec travis-ci bash -c "pip3 install --user /primitiv-python/dist/primitiv-*.tar.gz --verbose"
+    docker exec travis-ci bash -c "pip3 install --user /primitiv-python/dist/primitiv-*.tar.gz --verbose --global-option --enable-opencl"
     docker exec travis-ci bash -c "python3 -c 'import primitiv; dev = primitiv.devices.Naive()'"
     docker exec travis-ci bash -c "pip3 uninstall -y primitiv"
 else

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,16 @@ import numpy as np
 
 from Cython.Build import build_ext
 
+VERSION = "0.0.2"
 
 SUBMODULE_DIR = "primitiv-core"
 SUBMODULE_CMAKELIST = os.path.join(SUBMODULE_DIR, "CMakeLists.txt")
+
+build_number = os.getenv("PRIMITIV_PYTHON_BUILD_NUMBER")
+if build_number is not None:
+    version_full = VERSION + "." + build_number
+else:
+    version_full = VERSION
 
 dirname = os.path.dirname(os.path.abspath(__file__))
 
@@ -155,11 +162,11 @@ with open(os.path.join(dirname, "MANIFEST.in"), "w") as fp:
 
 setup(
     name="primitiv",
-    version="0.0.1",
+    version=version_full,
     description="primitiv: A Neural Network Toolkit. (Python frontend)",
-    url="https://github.com/odashi/primitiv",
-    author="Koichi Akabe",
-    author_email="vbkaisetsu at gmail.com",
+    url="https://github.com/primitiv/primitiv-python",
+    author="primitiv Developers",
+    author_email="primitiv-developer-group@googlegroups.com",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",


### PR DESCRIPTION
This branch adds Travis CI scripts to run test cases on four platforms.

In addition, it uploads a source package to PyPI when all tests are successfully finished on `master` or `develop` branch.
The version number is generated by the following rules:
* `develop` branch: `${VERSION}.dev${BUILD_NUMBER}`
* `master` branch: `${VERSION}.${BUILD_NUMBER}`
* other branches: do not deploy

where `${VERSION}` is specified in `setup.py`, and `${BUILD_NUMBER}` is given by Travis CI.

e.g.
```
 master          develop

0.2.0.103 <- release!
               0.2.0.dev105
               0.2.1.dev112 <- bump version
               0.2.1.dev120
               0.2.1.dev123
0.2.1.124  <- release!
               0.2.1.dev130
               0.2.2.dev135 <- bump version
0.2.2.136  <- release!
```

If normal releases are provided, `dev` releases are not installed by `pip` without `--pre` option.
`dev` makes a version older than the version without `dev` (i.e. `0.2.0.dev105 < 0.2.0.103 < 0.2.1.dev112 < 0.2.1.dev123 < 0.2.1.124`)

I uploaded some versions to https://pypi.python.org/pypi/primitiv for checking behaviour.
Here is a version containing the description: https://pypi.python.org/pypi/primitiv/0.0.2.2.dev32