### PR TITLE
Fix bugs in Travis script

### DIFF
--- a/.travis/debian.sh
+++ b/.travis/debian.sh
@@ -21,8 +21,8 @@ docker exec travis-ci bash -c "cd ./pocl && make && make install"
 
 if [ "${WITH_CORE_LIBRARY}" = "yes" ]; then
     # script
-    docker exec travis-ci bash -c "cd /primitiv-python && git submodule update --init"
-    docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py build --enable-opencl && ./setup.py test"
+    docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py build --enable-opencl"
+    docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py test --enable-opencl"
 
     # test installing by "pip install"
     docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py sdist --bundle-core-library"
@@ -34,21 +34,27 @@ if [ "${WITH_CORE_LIBRARY}" = "yes" ]; then
     docker exec travis-ci bash -c "pip3 install --user /primitiv-python/dist/primitiv-*.tar.gz --verbose --global-option --enable-opencl"
     docker exec travis-ci bash -c "python3 -c 'import primitiv; dev = primitiv.devices.Naive()'"
     docker exec travis-ci bash -c "pip3 uninstall -y primitiv"
+
+    # test installing by "./setup.py install"
+    docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py install --enable-opencl"
+    docker exec travis-ci bash -c "python3 -c 'import primitiv; dev = primitiv.devices.Naive()'"
+    docker exec travis-ci bash -c "pip3 uninstall -y primitiv"
 else
     # install core library
-    docker exec travis-ci bash -c "git clone https://github.com/primitiv/primitiv.git libprimitiv"
-    docker exec travis-ci bash -c "cd ./libprimitiv && cmake . -DPRIMITIV_USE_OPENCL=ON"
-    docker exec travis-ci bash -c "cd ./libprimitiv && make && make install"
+    docker exec travis-ci bash -c "cd /primitiv-python/primitiv-core && cmake . -DPRIMITIV_USE_OPENCL=ON"
+    docker exec travis-ci bash -c "cd /primitiv-python/primitiv-core && make"
+    docker exec travis-ci bash -c "cd /primitiv-python/primitiv-core && make install"
     docker exec travis-ci bash -c "ldconfig"
 
     # script
-    docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py build --enable-opencl && ./setup.py test"
-fi
+    docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py build --enable-opencl --no-build-core-library"
+    docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py test --enable-opencl --no-build-core-library"
 
-# test installing by "./setup.py install"
-docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py install --enable-opencl"
-docker exec travis-ci bash -c "python3 -c 'import primitiv; dev = primitiv.devices.Naive()'"
-docker exec travis-ci bash -c "pip3 uninstall -y primitiv"
+    # test installing by "./setup.py install"
+    docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py install --enable-opencl --no-build-core-library"
+    docker exec travis-ci bash -c "python3 -c 'import primitiv; dev = primitiv.devices.Naive()'"
+    docker exec travis-ci bash -c "pip3 uninstall -y primitiv"
+fi
 
 # after_script
 docker stop travis-ci

--- a/.travis/osx.sh
+++ b/.travis/osx.sh
@@ -13,7 +13,8 @@ mkdir work
 if [ "${WITH_CORE_LIBRARY}" = "yes" ]; then
     # script
     git submodule update --init
-    ./setup.py build && ./setup.py test
+    ./setup.py build
+    ./setup.py test
 
     # test installing by "pip install"
     ./setup.py sdist --bundle-core-library
@@ -29,18 +30,27 @@ if [ "${WITH_CORE_LIBRARY}" = "yes" ]; then
     python3 -c 'import primitiv; dev = primitiv.devices.Naive()'
     popd
     pip3 uninstall -y primitiv
-else
-    git clone https://github.com/primitiv/primitiv.git libprimitiv
-    pushd libprimitiv
-    cmake .
-    make && make install
+
+    # test installing by "./setup.py install"
+    ./setup.py install
+    pushd work
+    python3 -c 'import primitiv; dev = primitiv.devices.Naive()'
     popd
-    ./setup.py build && ./setup.py test
+    pip3 uninstall -y primitiv
+else
+    pushd primitiv-core
+    cmake .
+    make
+    make install
+    popd
+    ./setup.py build --no-build-core-library
+    ./setup.py test --no-build-core-library
+
+    # test installing by "./setup.py install"
+    ./setup.py install --no-build-core-library
+    pushd work
+    python3 -c 'import primitiv; dev = primitiv.devices.Naive()'
+    popd
+    pip3 uninstall -y primitiv
 fi
 
-# test installing by "./setup.py install"
-./setup.py install
-pushd work
-python3 -c 'import primitiv; dev = primitiv.devices.Naive()'
-popd
-pip3 uninstall -y primitiv

--- a/.travis/ubuntu.sh
+++ b/.travis/ubuntu.sh
@@ -21,8 +21,8 @@ docker exec travis-ci bash -c "cd ./pocl && make && make install"
 
 if [ "${WITH_CORE_LIBRARY}" = "yes" ]; then
     # script
-    docker exec travis-ci bash -c "cd /primitiv-python && git submodule update --init"
-    docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py build --enable-opencl && ./setup.py test"
+    docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py build --enable-opencl"
+    docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py test --enable-opencl"
 
     # test installing by "pip install"
     docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py sdist --bundle-core-library"
@@ -34,21 +34,27 @@ if [ "${WITH_CORE_LIBRARY}" = "yes" ]; then
     docker exec travis-ci bash -c "pip3 install --user /primitiv-python/dist/primitiv-*.tar.gz --verbose --global-option --enable-opencl"
     docker exec travis-ci bash -c "python3 -c 'import primitiv; dev = primitiv.devices.Naive()'"
     docker exec travis-ci bash -c "pip3 uninstall -y primitiv"
+
+    # test installing by "./setup.py install"
+    docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py install --enable-opencl"
+    docker exec travis-ci bash -c "python3 -c 'import primitiv; dev = primitiv.devices.Naive()'"
+    docker exec travis-ci bash -c "pip3 uninstall -y primitiv"
 else
     # install core library
-    docker exec travis-ci bash -c "git clone https://github.com/primitiv/primitiv.git libprimitiv"
-    docker exec travis-ci bash -c "cd ./libprimitiv && cmake . -DPRIMITIV_USE_OPENCL=ON"
-    docker exec travis-ci bash -c "cd ./libprimitiv && make && make install"
+    docker exec travis-ci bash -c "cd /primitiv-python/primitiv-core && cmake . -DPRIMITIV_USE_OPENCL=ON"
+    docker exec travis-ci bash -c "cd /primitiv-python/primitiv-core && make"
+    docker exec travis-ci bash -c "cd /primitiv-python/primitiv-core && make install"
     docker exec travis-ci bash -c "ldconfig"
 
     # script
-    docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py build --enable-opencl && ./setup.py test"
-fi
+    docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py build --enable-opencl --no-build-core-library"
+    docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py test --enable-opencl --no-build-core-library"
 
-# test installing by "./setup.py install"
-docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py install --enable-opencl"
-docker exec travis-ci bash -c "python3 -c 'import primitiv; dev = primitiv.devices.Naive()'"
-docker exec travis-ci bash -c "pip3 uninstall -y primitiv"
+    # test installing by "./setup.py install"
+    docker exec travis-ci bash -c "cd /primitiv-python && ./setup.py install --enable-opencl --no-build-core-library"
+    docker exec travis-ci bash -c "python3 -c 'import primitiv; dev = primitiv.devices.Naive()'"
+    docker exec travis-ci bash -c "pip3 uninstall -y primitiv"
+fi
 
 # after_script
 docker stop travis-ci


### PR DESCRIPTION
This branch fixes Travis CI scripts.
The previous version does not test the situation that modules are built without the core library, because Travis automatically downloads the core library as a submodule.

This branch uses `--no-build-core-library` to ignore the submodule.