### PR TITLE
Fix return value of Shape.resize_dim() and Shape.resize_batch()

### DIFF
--- a/primitiv/_shape.pxd
+++ b/primitiv/_shape.pxd
@@ -32,6 +32,8 @@ cdef extern from "primitiv/shape.h":
 
 cdef class Shape:
     cdef CppShape wrapped
+    @staticmethod
+    cdef Shape get_wrapper(CppShape wrapped)
 
 
 cdef inline Shape wrapShape(CppShape wrapped) except +:

--- a/primitiv/_shape.pyx
+++ b/primitiv/_shape.pyx
@@ -186,8 +186,7 @@ cdef class Shape:
         :rtype: primitiv.Shape
 
         """
-        self.wrapped.resize_dim(dim, m)
-        return self
+        return Shape.get_wrapper(self.wrapped.resize_dim(dim, m))
 
     def resize_batch(self, unsigned batch):
         """Creates a new shape which have specified batch size.
@@ -198,8 +197,7 @@ cdef class Shape:
         :rtype: primitiv.Shape
 
         """
-        self.wrapped.resize_batch(batch)
-        return self
+        return Shape.get_wrapper(self.wrapped.resize_batch(batch))
 
     def update_dim(self, unsigned dim, unsigned m):
         """Directly updates a specified dimension.
@@ -226,3 +224,9 @@ cdef class Shape:
 
     def __deepcopy__(self, memo):
         raise NotImplementedError(type(self).__name__ + " does not support `__deepcopy__` for now.")
+
+    @staticmethod
+    cdef Shape get_wrapper(CppShape wrapped):
+        cdef Shape shape = Shape.__new__(Shape)
+        shape.wrapped = wrapped
+        return shape


### PR DESCRIPTION
Previously `Shape.resize_dim()` and `Shape.resize_batch()` returned `self`.
This branch fix them.