### PR TITLE
Add cmake to required packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Dependencies
 * NumPy (1.11.0 or later)
 * Cython (0.27 or later)
 * CMake (3.1.0 or later)
-* scikit-build (0.6.1 or later, only for building)
+* scikit-build (0.6.1 or later)
 * (optional) CUDA (7.5 or later)
 * (optional) OpenCL (1.2 or later) and OpenCL C++ binding v2
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Dependencies
 * Python 3 (3.5 or later)
 * NumPy (1.11.0 or later)
 * Cython (0.27 or later)
+* CMake (3.1.0 or later)
 * scikit-build (0.6.1 or later, only for building)
 * (optional) CUDA (7.5 or later)
 * (optional) OpenCL (1.2 or later) and OpenCL C++ binding v2
@@ -29,7 +30,7 @@ Getting Started
 To install primitiv without CUDA and OpenCL, run the following commands:
 
 ```
-$ pip3 install numpy cython scikit-build [--user]
+$ pip3 install numpy cython cmake scikit-build [--user]
 $ pip3 install primitiv [--user]
 ```
 
@@ -51,10 +52,10 @@ while keeping compatibility with the `manylinux1` standard described in
 
 ### Compiling Step by Step
 
-1. Install NumPy, Cython and scikit-build with Python 3
+1. Install NumPy, Cython, CMake and scikit-build with Python 3
 
 ```
-$ sudo pip3 install numpy cython scikit-build
+$ sudo pip3 install numpy cython cmake scikit-build
 ```
 
 2. Run following commands in `primitiv-python` directory:

--- a/package_description.rst
+++ b/package_description.rst
@@ -21,7 +21,7 @@ Prerequisites:
 - NumPy (1.11.0 or later)
 - Cython (0.27 or later)
 - CMake (3.1.0 or later)
-- scikit-build (0.6.1 or later, only for building)
+- scikit-build (0.6.1 or later)
 - (optional) CUDA (7.5 or later)
 - (optional) OpenCL (1.2 or later) and OpenCL C++ binding v2
 

--- a/package_description.rst
+++ b/package_description.rst
@@ -20,13 +20,14 @@ Prerequisites:
 - Python 3 (3.5 or later)
 - NumPy (1.11.0 or later)
 - Cython (0.27 or later)
+- CMake (3.1.0 or later)
 - scikit-build (0.6.1 or later, only for building)
 - (optional) CUDA (7.5 or later)
 - (optional) OpenCL (1.2 or later) and OpenCL C++ binding v2
 
 Install dependencies::
 
-    pip3 install numpy cython scikit-build
+    pip3 install numpy cython cmake scikit-build
 
 Build and install primitiv without CUDA and OpenCL::
 


### PR DESCRIPTION
This branch fix `pip` command on the documentation to install `cmake`.

If CMake 3.1 or higher is already installed in the machine, this package is not necessary. However, I want to reduce conditional branches in the document.
`cmake` package is installed to the python prefix, and users can use system's one by default. On the other hand, `scikit-build` uses PyPI's cmake.

In travis scripts, cmake is installed from linux distribution's repository instead of PyPI, because it is also used to compile OpenCL platform (POCL and clBLAS). It is nonsense to use PyPI's CMake for these softwares that are not related to Python.