### PR TITLE
Remove Model.scan_attributes() from examples

### DIFF
--- a/examples/encdec/encdec.py
+++ b/examples/encdec/encdec.py
@@ -52,7 +52,6 @@ class EncoderDecoder(Model):
         self.pby = Parameter()
         self.src_lstm = LSTM()
         self.trg_lstm = LSTM()
-        self.scan_attributes()
 
     def init(self, src_vocab_size, trg_vocab_size, embed_size, hidden_size):
         """Creates a new EncoderDecoder object."""

--- a/examples/encdec/encdec_attention.py
+++ b/examples/encdec/encdec_attention.py
@@ -54,7 +54,6 @@ class AttentionalEncoderDecoder(Model):
         self.src_fw_lstm = LSTM()
         self.src_bw_lstm = LSTM()
         self.trg_lstm = LSTM()
-        self.scan_attributes()
 
     def init(self, src_vocab_size, trg_vocab_size, embed_size, hidden_size):
         """Creates a new AttentionalEncoderDecoder object."""

--- a/examples/encdec/lstm.py
+++ b/examples/encdec/lstm.py
@@ -21,7 +21,6 @@ class LSTM(Model):
         self.pwxh = Parameter()
         self.pwhh = Parameter()
         self.pbh = Parameter()
-        self.scan_attributes()
 
     def init(self, in_size, out_size):
         """Creates a new LSTM."""

--- a/examples/ptb/ptb_rnnlm.py
+++ b/examples/ptb/ptb_rnnlm.py
@@ -24,7 +24,6 @@ class RNNLM(Model):
         self.pwlookup = Parameter([NUM_HIDDEN_UNITS, vocab_size], I.XavierUniform())
         self.pwxs = Parameter([NUM_HIDDEN_UNITS, NUM_HIDDEN_UNITS], I.XavierUniform())
         self.pwsy = Parameter([vocab_size, NUM_HIDDEN_UNITS], I.XavierUniform())
-        self.scan_attributes()
 
     # Forward function of RNNLM. Input data should be arranged below:
     # inputs = {

--- a/examples/ptb/ptb_rnnlm_lstm.py
+++ b/examples/ptb/ptb_rnnlm_lstm.py
@@ -25,7 +25,6 @@ class Affine(Model):
     def __init__(self, in_size, out_size):
         self.pw = Parameter([out_size, in_size], I.Uniform(-0.1, 0.1))
         self.pb = Parameter([out_size], I.Constant(0))
-        self.scan_attributes()
 
     # Initializes internal values.
     def reset(self):
@@ -52,7 +51,6 @@ class LSTM(Model):
         self.pwxh = Parameter([4 * out_size, in_size], I.Uniform(-0.1, 0.1))
         self.pwhh = Parameter([4 * out_size, out_size], I.Uniform(-0.1, 0.1))
         self.pbh = Parameter([4 * out_size], I.Constant(0))
-        self.scan_attributes()
 
     # Initializes internal values.
     def restart(self):
@@ -82,7 +80,6 @@ class RNNLM(Model):
         self.rnn1 = LSTM(NUM_HIDDEN_UNITS, NUM_HIDDEN_UNITS)
         self.rnn2 = LSTM(NUM_HIDDEN_UNITS, NUM_HIDDEN_UNITS)
         self.hy = Affine(NUM_HIDDEN_UNITS, vocab_size)
-        self.scan_attributes()
 
 
     # Forward function of RNNLM. Input data should be arranged below:

--- a/examples/ptb/ptb_rnnlm_sru.py
+++ b/examples/ptb/ptb_rnnlm_sru.py
@@ -25,7 +25,6 @@ class Affine(Model):
     def __init__(self, in_size, out_size):
         self.pw = Parameter([out_size, in_size], I.Uniform(-0.1, 0.1))
         self.pb = Parameter([out_size], I.Constant(0))
-        self.scan_attributes()
 
     # Initializes internal values.
     def reset(self):
@@ -51,7 +50,6 @@ class SRU(Model):
         self.pw = Parameter([3 * out_size, in_size], I.Uniform(-0.1, 0.1))
         self.pbf = Parameter([out_size], I.Constant(0))
         self.pbr = Parameter([out_size], I.Constant(0))
-        self.scan_attributes()
 
     # Initializes internal values.
     def restart(self):
@@ -91,7 +89,6 @@ class RNNLM(Model):
         self.rnn1 = SRU(NUM_HIDDEN_UNITS, NUM_HIDDEN_UNITS)
         self.rnn2 = SRU(NUM_HIDDEN_UNITS, NUM_HIDDEN_UNITS)
         self.hy = Affine(NUM_HIDDEN_UNITS, vocab_size)
-        self.scan_attributes()
 
     # Forward function of RNNLM. Input data should be arranged below:
     # inputs = {


### PR DESCRIPTION
This branch removes `self.scan_attributes()` from examples. `self.scan_attributes()` was merged with `self.__setattr__()`