### PR TITLE
Implement contrib functions in Python

### DIFF
--- a/primitiv/_device.pxd
+++ b/primitiv/_device.pxd
@@ -1,4 +1,4 @@
-cdef extern from "primitiv/device.h":
+cdef extern from "primitiv/core/device.h":
     cdef cppclass CppDevice "primitiv::Device":
         void dump_description() except +
 

--- a/primitiv/_function.pxd
+++ b/primitiv/_function.pxd
@@ -9,7 +9,7 @@ from primitiv._shape cimport CppShape
 from primitiv._parameter cimport CppParameter
 
 
-cdef extern from "primitiv/functions.h":
+cdef extern from "primitiv/core/basic_functions.h":
     CppTensor func_input_tensor "primitiv::functions::input_tensor" (const CppShape &shape, const vector[float] &data, CppDevice *dev) except +
     CppNode func_input_node "primitiv::functions::input_node" (const CppShape &shape, const vector[float] &data, CppDevice *dev, CppGraph *g) except +
     CppTensor func_parameter_tensor "primitiv::functions::parameter_tensor" (CppParameter &param) except +
@@ -40,12 +40,7 @@ cdef extern from "primitiv/functions.h":
     Var func_prelu "primitiv::functions::prelu" [Var](const Var &x, float a) except +
     Var func_elu "primitiv::functions::elu" [Var](const Var &x, float a) except +
     Var func_selu "primitiv::functions::selu" [Var](const Var &x, float a, float s) except +
-    CppNode func_sum "primitiv::functions::sum" (const vector[CppNode] &xs) except +
-    CppTensor func_sum "primitiv::functions::sum" (const vector[CppTensor] &xs) except +
     Var func_sum "primitiv::functions::sum" [Var](const Var &x, unsigned dim) except +
-    CppNode func_mean "primitiv::functions::mean" (const vector[CppNode] &xs) except +
-    CppTensor func_mean "primitiv::functions::mean" (const vector[CppTensor] &xs) except +
-    Var func_mean "primitiv::functions::mean" [Var](const Var &x, unsigned dim) except +
     Var func_broadcast "primitiv::functions::broadcast" [Var](const Var &x, unsigned dim, unsigned size) except +
     Var func_logsumexp "primitiv::functions::logsumexp" [Var](const Var &x, unsigned dim) except +
     Var func_log_softmax "primitiv::functions::log_softmax" [Var](const Var &x, unsigned dim) except +
@@ -58,13 +53,8 @@ cdef extern from "primitiv/functions.h":
 
     CppTensor func_constant_tensor "primitiv::functions::constant_tensor" (const CppShape &shape, float k, CppDevice *dev) except +
     CppNode func_constant_node "primitiv::functions::constant_node" (const CppShape &shape, float k, CppDevice *dev, CppGraph *g) except +
-    CppTensor func_zeros_tensor "primitiv::functions::zeros_tensor" (const CppShape &shape, CppDevice *dev) except +
-    CppNode func_zeros_node "primitiv::functions::zeros_node" (const CppShape &shape, CppDevice *dev, CppGraph *g) except +
-    CppTensor func_ones_tensor "primitiv::functions::ones_tensor" (const CppShape &shape, CppDevice *dev) except +
-    CppNode func_ones_node "primitiv::functions::ones_node" (const CppShape &shape, CppDevice *dev, CppGraph *g) except +
     CppTensor func_identity_tensor "primitiv::functions::identity_tensor" (unsigned size, CppDevice *dev) except +
     CppNode func_identity_node "primitiv::functions::identity_node" (unsigned size, CppDevice *dev, CppGraph *g) except +
-    Var func_dropout "primitiv::functions::dropout" [Var](const Var &x, float rate, bool enabled) except +
 
     Var func_positive "primitiv::functions::positive" [Var](const Var &x) except +
     Var func_negative "primitiv::functions::negative" [Var](const Var &x) except +
@@ -82,13 +72,11 @@ cdef extern from "primitiv/functions.h":
     Var func_divide "primitiv::functions::divide" [Var](const Var &a, const Var &b) except +
 
 
-cdef extern from "primitiv/functions.h":
+cdef extern from "primitiv/core/basic_functions.h":
     Var func_batch_sum "primitiv::functions::batch::sum" [Var](const Var &x) except +
-    Var func_batch_mean "primitiv::functions::batch::mean" [Var](const Var &x) except +
-    Var func_batch_normalize "primitiv::functions::batch::normalize" [Var](const Var &x) except +
 
 
-cdef extern from "primitiv/functions.h":
+cdef extern from "primitiv/core/basic_functions.h":
 
     CppNode func_random_bernoulli_node "primitiv::functions::random::bernoulli_node" (const CppShape &shape, float p, CppDevice *dev, CppGraph *g) except +
     CppTensor func_random_bernoulli_tensor "primitiv::functions::random::bernoulli_tensor" (const CppShape &shape, float p, CppDevice *dev) except +

--- a/primitiv/_graph.pxd
+++ b/primitiv/_graph.pxd
@@ -6,7 +6,7 @@ from primitiv._shape cimport CppShape
 from primitiv._tensor cimport CppTensor
 
 
-cdef extern from "primitiv/graph.h" nogil:
+cdef extern from "primitiv/core/graph.h" nogil:
     cdef cppclass CppNode "primitiv::Node":
         CppNode(CppNode &&src) except +
         CppNode() except +
@@ -23,7 +23,7 @@ cdef extern from "primitiv/graph.h" nogil:
         void backward() except +
 
 
-cdef extern from "primitiv/graph.h" nogil:
+cdef extern from "primitiv/core/graph.h" nogil:
     cdef cppclass CppGraph "primitiv::Graph":
         CppGraph() except +
         void clear() except +

--- a/primitiv/_initializer.pxd
+++ b/primitiv/_initializer.pxd
@@ -1,7 +1,7 @@
 from primitiv._tensor cimport CppTensor
 
 
-cdef extern from "primitiv/initializer.h":
+cdef extern from "primitiv/core/initializer.h":
     cdef cppclass CppInitializer "primitiv::Initializer":
         CppInitializer() except +
         void apply(CppTensor &x) except +

--- a/primitiv/_model.pxd
+++ b/primitiv/_model.pxd
@@ -7,7 +7,7 @@ from primitiv._device cimport CppDevice
 from primitiv._parameter cimport CppParameter
 
 
-cdef extern from "primitiv/model.h":
+cdef extern from "primitiv/core/model.h":
     cdef cppclass CppModel "primitiv::Model":
         CppModel() except +
         void load(string &path, bool with_stats, CppDevice *device) except +

--- a/primitiv/_optimizer.pxd
+++ b/primitiv/_optimizer.pxd
@@ -10,7 +10,7 @@ from primitiv._parameter cimport CppParameter, Parameter
 from primitiv._shape cimport CppShape
 
 
-cdef extern from "primitiv/optimizer.h":
+cdef extern from "primitiv/core/optimizer.h":
     cdef cppclass CppOptimizer "primitiv::Optimizer":
         CppOptimizer(CppOptimizer &&) except +
         CppOptimizer() except +

--- a/primitiv/_parameter.pxd
+++ b/primitiv/_parameter.pxd
@@ -9,7 +9,7 @@ from primitiv._device cimport CppDevice
 from primitiv._initializer cimport CppInitializer, Initializer
 
 
-cdef extern from "primitiv/parameter.h":
+cdef extern from "primitiv/core/parameter.h":
     cdef cppclass CppParameter "primitiv::Parameter":
         CppParameter() except +
         CppParameter(const CppShape &shape, const vector[float] &value, CppDevice *device) except +

--- a/primitiv/_shape.pxd
+++ b/primitiv/_shape.pxd
@@ -3,7 +3,7 @@ from libcpp.string cimport string
 from libcpp cimport bool
 
 
-cdef extern from "primitiv/shape.h":
+cdef extern from "primitiv/core/shape.h":
     cdef cppclass CppShape "primitiv::Shape":
         CppShape() except +
         CppShape(vector[unsigned] &dims, unsigned batch) except +

--- a/primitiv/_tensor.pxd
+++ b/primitiv/_tensor.pxd
@@ -5,7 +5,7 @@ from primitiv._device cimport CppDevice
 from primitiv._shape cimport CppShape
 
 
-cdef extern from "primitiv/tensor.h" nogil:
+cdef extern from "primitiv/core/tensor.h" nogil:
     cdef cppclass CppTensor "primitiv::Tensor":
         CppTensor(CppTensor &&src) except +
         CppTensor() except +

--- a/primitiv/devices/_cuda_device.pxd
+++ b/primitiv/devices/_cuda_device.pxd
@@ -1,7 +1,7 @@
 from primitiv._device cimport CppDevice, Device
 
 
-cdef extern from "primitiv/cuda_device.h":
+cdef extern from "primitiv/devices/cuda/device.h":
     cdef cppclass CppCUDA "primitiv::devices::CUDA" (CppDevice):
         CppCUDA(unsigned device_id) except +
         CppCUDA(unsigned device_id, unsigned rng_seed) except +

--- a/primitiv/devices/_eigen_device.pxd
+++ b/primitiv/devices/_eigen_device.pxd
@@ -1,7 +1,7 @@
 from primitiv._device cimport CppDevice, Device
 
 
-cdef extern from "primitiv/eigen_device.h":
+cdef extern from "primitiv/devices/eigen/device.h":
     cdef cppclass CppEigen "primitiv::devices::Eigen" (CppDevice):
         CppEigen() except +
         CppEigen(unsigned rng_seed) except +

--- a/primitiv/devices/_naive_device.pxd
+++ b/primitiv/devices/_naive_device.pxd
@@ -1,7 +1,7 @@
 from primitiv._device cimport CppDevice, Device
 
 
-cdef extern from "primitiv/naive_device.h":
+cdef extern from "primitiv/devices/naive/device.h":
     cdef cppclass CppNaive "primitiv::devices::Naive" (CppDevice):
         CppNaive() except +
         CppNaive(unsigned rng_seed) except +

--- a/primitiv/devices/_opencl_device.pxd
+++ b/primitiv/devices/_opencl_device.pxd
@@ -1,7 +1,7 @@
 from primitiv._device cimport CppDevice, Device
 
 
-cdef extern from "primitiv/opencl_device.h":
+cdef extern from "primitiv/devices/opencl/device.h":
     cdef cppclass CppOpenCL "primitiv::devices::OpenCL" (CppDevice):
         CppOpenCL(unsigned platform_id, unsigned device_id) except +
         CppOpenCL(unsigned platform_id, unsigned device_id, unsigned rng_seed) except +

--- a/primitiv/initializers/_initializer_impl.pxd
+++ b/primitiv/initializers/_initializer_impl.pxd
@@ -1,7 +1,7 @@
 from primitiv._initializer cimport CppInitializer, Initializer
 
 
-cdef extern from "primitiv/initializer_impl.h":
+cdef extern from "primitiv/core/initializer_impl.h":
     cdef cppclass CppConstant "primitiv::initializers::Constant" (CppInitializer):
         CppConstant(float k)
 

--- a/primitiv/optimizers/_optimizer_impl.pxd
+++ b/primitiv/optimizers/_optimizer_impl.pxd
@@ -5,7 +5,7 @@ from primitiv._device cimport CppDevice
 from primitiv._optimizer cimport CppOptimizer, Optimizer
 
 
-cdef extern from "primitiv/optimizer_impl.h":
+cdef extern from "primitiv/core/optimizer_impl.h":
     cdef cppclass CppSGD "primitiv::optimizers::SGD" (CppOptimizer):
         CppSGD(float eta)
         float eta()

--- a/primitiv/py_optimizer.h
+++ b/primitiv/py_optimizer.h
@@ -1,8 +1,7 @@
 #ifndef PRIMITIV_PYTHON_PY_OPTIMIZER_H_
 #define PRIMITIV_PYTHON_PY_OPTIMIZER_H_
 
-#include <primitiv/optimizer.h>
-#include <iostream>
+#include <primitiv/core/optimizer.h>
 
 __PYX_EXTERN_C int primitiv_python_optimizer_get_configs(
                         PyObject *obj,


### PR DESCRIPTION
This branch implements contrib functions in Python.
Some contrib functions in C++ use `get_default()` internally but it returns `null` because the default object is stored in Python.