### PR TITLE
Build manylinux2010 packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,54 +34,36 @@ matrix:
     - stage: test
       os: osx
       env: SCRIPT=osx
-    - if: branch = develop
+    - if: branch IN (master, develop)
       stage: deploy
       os: linux
+      env: SCRIPT=manylinux2010 BINARY_PACKAGE=yes
       language: python
       python: 3.5
-      script:
-        - export PRIMITIV_PYTHON_BUILD_NUMBER="dev${TRAVIS_BUILD_NUMBER}"
-        - pip install cython numpy scikit-build twine
-        - wget "http://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2" -O eigen-downloaded.tar.gz
-        - mkdir ./eigen-downloaded
-        - tar xf ./eigen-downloaded.tar.gz --strip-components=1 -C ./eigen-downloaded
-        - $TRAVIS_BUILD_DIR/setup.py sdist --bundle-core-library --bundle-eigen-headers ./eigen-downloaded
-        - pip install $TRAVIS_BUILD_DIR/dist/primitiv-*.tar.gz
-        - mkdir ./work
-        - pushd ./work
-        - python -c "import primitiv; dev = primitiv.devices.Eigen()"
-        - popd
-      deploy:
-        skip_cleanup: true
-        provider: script
-        script: twine upload -u $PYPI_USERNAME -p $PYPI_PASSWORD $TRAVIS_BUILD_DIR/dist/primitiv-*.tar.gz
-        on:
-          tags: false
-          branch: develop
-    - if: branch = master
+    - if: branch IN (master, develop)
       stage: deploy
       os: linux
+      env: SCRIPT=manylinux2010 BINARY_PACKAGE=yes
       language: python
-      python: 3.5
-      script:
-        - export PRIMITIV_PYTHON_BUILD_NUMBER="${TRAVIS_BUILD_NUMBER}"
-        - pip install cython numpy scikit-build twine
-        - wget "http://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2" -O eigen-downloaded.tar.gz
-        - mkdir ./eigen-downloaded
-        - tar xf ./eigen-downloaded.tar.gz --strip-components=1 -C ./eigen-downloaded
-        - $TRAVIS_BUILD_DIR/setup.py sdist --bundle-core-library --bundle-eigen-headers ./eigen-downloaded
-        - pip install $TRAVIS_BUILD_DIR/dist/primitiv-*.tar.gz
-        - mkdir ./work
-        - pushd ./work
-        - python -c "import primitiv; dev = primitiv.devices.Eigen()"
-        - popd
-      deploy:
-        skip_cleanup: true
-        provider: script
-        script: twine upload -u $PYPI_USERNAME -p $PYPI_PASSWORD $TRAVIS_BUILD_DIR/dist/primitiv-*.tar.gz
-        on:
-          tags: false
-          branch: master
+      python: 3.6
+    - if: branch IN (master, develop)
+      stage: deploy
+      os: linux
+      env: SCRIPT=sdist
+      language: python
+      python: 3.6
 
 script:
   - $TRAVIS_BUILD_DIR/.travis/${SCRIPT}.sh
+
+deploy:
+  skip_cleanup: true
+  provider: script
+  script:
+    - $TRAVIS_BUILD_DIR/.travis/deploy.sh
+  on:
+    tags: false
+    condition: $TRAVIS_BUILD_STAGE_NAME = Deploy
+    branch:
+      - develop
+      - master

--- a/.travis/debian.sh
+++ b/.travis/debian.sh
@@ -7,8 +7,9 @@ docker run --name travis-ci -v $TRAVIS_BUILD_DIR:/primitiv-python -td debian:sta
 
 # install
 docker exec travis-ci bash -c "apt update"
-docker exec travis-ci bash -c "apt install -y build-essential cmake python3-dev python3-pip python3-numpy"
-docker exec travis-ci bash -c "pip3 install cython scikit-build"
+docker exec travis-ci bash -c "apt install -y build-essential cmake python3-dev python3-pip"
+docker exec travis-ci bash -c "pip3 install -U pip setuptools"
+docker exec travis-ci bash -c "pip3 install cython scikit-build numpy"
 
 # TODO(vbkaisetsu):
 # Debian stretch contains Eigen 3.3.2. It has a bug around EIGEN_MPL2_ONLY
@@ -26,7 +27,7 @@ docker exec travis-ci bash -c "cd ./eigen/build && cmake .."
 docker exec travis-ci bash -c "cd ./eigen/build && make && make install"
 
 # install OpenCL environment
-docker exec travis-ci bash -c "apt install -y opencl-headers git pkg-config libhwloc-dev libltdl-dev ocl-icd-dev ocl-icd-opencl-dev clang-3.8 llvm-3.8-dev libclang-3.8-dev libz-dev"
+docker exec travis-ci bash -c "apt install -y opencl-headers git pkg-config libhwloc-dev libltdl-dev ocl-icd-dev ocl-icd-opencl-dev clang-4.0 llvm-4.0-dev libclang-4.0-dev libz-dev"
 docker exec travis-ci bash -c "wget https://github.com/CNugteren/CLBlast/archive/1.2.0.tar.gz -O ./clblast.tar.gz"
 docker exec travis-ci bash -c "mkdir ./clblast"
 docker exec travis-ci bash -c "tar xf ./clblast.tar.gz -C ./clblast --strip-components 1"

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -xe
+
+pip install twine
+if [ "${BINARY_PACKAGE}" = "yes" ]; then
+  twine upload -u "${PYPI_USERNAME}" -p "${PYPI_PASSWORD}" $TRAVIS_BUILD_DIR/wheelhouse/primitiv-*.whl;
+else
+  twine upload -u "${PYPI_USERNAME}" -p "${PYPI_PASSWORD}" $TRAVIS_BUILD_DIR/dist/primitiv-*.tar.gz;
+fi

--- a/.travis/manylinux2010.sh
+++ b/.travis/manylinux2010.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -xe
+
+if [ "${TRAVIS_BRANCH}" = "develop" ]; then
+  PRIMITIV_PYTHON_BUILD_NUMBER="dev${TRAVIS_BUILD_NUMBER}"
+else
+  PRIMITIV_PYTHON_BUILD_NUMBER="${TRAVIS_BUILD_NUMBER}"
+fi
+
+# before_install
+docker pull vbkaisetsu/manylinux2010-py3-cmake
+docker run --name travis-ci -v ${TRAVIS_BUILD_DIR}:/primitiv-python --env PRIMITIV_PYTHON_BUILD_NUMBER=${PRIMITIV_PYTHON_BUILD_NUMBER} -td vbkaisetsu/manylinux2010-py3-cmake:${TRAVIS_PYTHON_VERSION} /bin/bash
+
+# install
+docker exec travis-ci bash -c "pip${TRAVIS_PYTHON_VERSION} install numpy==1.16.1 cython scikit-build auditwheel wheel==0.31.1"
+
+docker exec travis-ci bash -c "cd /primitiv-python && wget -q http://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2 -O eigen-downloaded.tar.gz"
+docker exec travis-ci bash -c "cd /primitiv-python && mkdir ./eigen-downloaded"
+docker exec travis-ci bash -c "cd /primitiv-python && tar xf ./eigen-downloaded.tar.gz --strip-components=1 -C ./eigen-downloaded"
+
+# source package
+docker exec travis-ci bash -c "cd /primitiv-python && python${TRAVIS_PYTHON_VERSION} ./setup.py sdist --bundle-core-library --bundle-eigen-headers ./eigen-downloaded"
+
+# script
+docker exec travis-ci bash -c "cd /primitiv-python && python${TRAVIS_PYTHON_VERSION} ./setup.py build --enable-eigen -- -DCMAKE_VERBOSE_MAKEFILE=ON"
+docker exec travis-ci bash -c "cd /primitiv-python && python${TRAVIS_PYTHON_VERSION} ./setup.py build_ext -i --enable-eigen -- -DCMAKE_VERBOSE_MAKEFILE=ON"
+docker exec travis-ci bash -c "cd /primitiv-python && python${TRAVIS_PYTHON_VERSION} ./setup.py test"
+
+# binary package
+docker exec travis-ci bash -c "cd /primitiv-python && python${TRAVIS_PYTHON_VERSION} ./setup.py bdist_wheel"
+docker exec travis-ci bash -c "cd /primitiv-python && /usr/bin/auditwheel repair --plat manylinux2010_x86_64 dist/primitiv-*.whl"
+
+# after_script
+docker stop travis-ci
+
+pip install -U pip
+pip install ${TRAVIS_BUILD_DIR}/wheelhouse/primitiv-*.whl
+mkdir ./work
+pushd ./work
+python -c "import primitiv; dev = primitiv.devices.Eigen()"
+popd

--- a/.travis/sdist.sh
+++ b/.travis/sdist.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -xe
+
+if [ "${TRAVIS_BRANCH}" = "develop" ]; then
+  PRIMITIV_PYTHON_BUILD_NUMBER="dev${TRAVIS_BUILD_NUMBER}"
+else
+  PRIMITIV_PYTHON_BUILD_NUMBER="${TRAVIS_BUILD_NUMBER}"
+fi
+
+export PRIMITIV_PYTHON_BUILD_NUMBER
+
+pip install cython numpy scikit-build
+wget -q "http://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2" -O eigen-downloaded.tar.gz
+mkdir ./eigen-downloaded
+tar xf ./eigen-downloaded.tar.gz --strip-components=1 -C ./eigen-downloaded
+${TRAVIS_BUILD_DIR}/setup.py sdist --bundle-core-library --bundle-eigen-headers ./eigen-downloaded
+pip install ${TRAVIS_BUILD_DIR}/dist/primitiv-*.tar.gz
+mkdir ./work
+pushd ./work
+python -c "import primitiv; dev = primitiv.devices.Eigen()"
+popd

--- a/primitiv/_device.pxd
+++ b/primitiv/_device.pxd
@@ -1,4 +1,4 @@
-cdef extern from "primitiv/device.h":
+cdef extern from "primitiv/core/device.h":
     cdef cppclass CppDevice "primitiv::Device":
         void dump_description() except +
 

--- a/primitiv/_function.pxd
+++ b/primitiv/_function.pxd
@@ -9,7 +9,7 @@ from primitiv._shape cimport CppShape
 from primitiv._parameter cimport CppParameter
 
 
-cdef extern from "primitiv/functions.h":
+cdef extern from "primitiv/core/functions.h":
     CppTensor func_input_tensor "primitiv::functions::input_tensor" (const CppShape &shape, const vector[float] &data, CppDevice *dev) except +
     CppNode func_input_node "primitiv::functions::input_node" (const CppShape &shape, const vector[float] &data, CppDevice *dev, CppGraph *g) except +
     CppTensor func_parameter_tensor "primitiv::functions::parameter_tensor" (CppParameter &param) except +
@@ -82,13 +82,13 @@ cdef extern from "primitiv/functions.h":
     Var func_divide "primitiv::functions::divide" [Var](const Var &a, const Var &b) except +
 
 
-cdef extern from "primitiv/functions.h":
+cdef extern from "primitiv/core/functions.h":
     Var func_batch_sum "primitiv::functions::batch::sum" [Var](const Var &x) except +
     Var func_batch_mean "primitiv::functions::batch::mean" [Var](const Var &x) except +
     Var func_batch_normalize "primitiv::functions::batch::normalize" [Var](const Var &x) except +
 
 
-cdef extern from "primitiv/functions.h":
+cdef extern from "primitiv/core/functions.h":
 
     CppNode func_random_bernoulli_node "primitiv::functions::random::bernoulli_node" (const CppShape &shape, float p, CppDevice *dev, CppGraph *g) except +
     CppTensor func_random_bernoulli_tensor "primitiv::functions::random::bernoulli_tensor" (const CppShape &shape, float p, CppDevice *dev) except +

--- a/primitiv/_graph.pxd
+++ b/primitiv/_graph.pxd
@@ -6,7 +6,7 @@ from primitiv._shape cimport CppShape
 from primitiv._tensor cimport CppTensor
 
 
-cdef extern from "primitiv/graph.h" nogil:
+cdef extern from "primitiv/core/graph.h" nogil:
     cdef cppclass CppNode "primitiv::Node":
         CppNode(CppNode &&src) except +
         CppNode() except +
@@ -23,7 +23,7 @@ cdef extern from "primitiv/graph.h" nogil:
         void backward() except +
 
 
-cdef extern from "primitiv/graph.h" nogil:
+cdef extern from "primitiv/core/graph.h" nogil:
     cdef cppclass CppGraph "primitiv::Graph":
         CppGraph() except +
         void clear() except +

--- a/primitiv/_initializer.pxd
+++ b/primitiv/_initializer.pxd
@@ -1,7 +1,7 @@
 from primitiv._tensor cimport CppTensor
 
 
-cdef extern from "primitiv/initializer.h":
+cdef extern from "primitiv/core/initializer.h":
     cdef cppclass CppInitializer "primitiv::Initializer":
         CppInitializer() except +
         void apply(CppTensor &x) except +

--- a/primitiv/_model.pxd
+++ b/primitiv/_model.pxd
@@ -7,7 +7,7 @@ from primitiv._device cimport CppDevice
 from primitiv._parameter cimport CppParameter
 
 
-cdef extern from "primitiv/model.h":
+cdef extern from "primitiv/core/model.h":
     cdef cppclass CppModel "primitiv::Model":
         CppModel() except +
         void load(string &path, bool with_stats, CppDevice *device) except +

--- a/primitiv/_optimizer.pxd
+++ b/primitiv/_optimizer.pxd
@@ -10,7 +10,7 @@ from primitiv._parameter cimport CppParameter, Parameter
 from primitiv._shape cimport CppShape
 
 
-cdef extern from "primitiv/optimizer.h":
+cdef extern from "primitiv/core/optimizer.h":
     cdef cppclass CppOptimizer "primitiv::Optimizer":
         CppOptimizer(CppOptimizer &&) except +
         CppOptimizer() except +

--- a/primitiv/_parameter.pxd
+++ b/primitiv/_parameter.pxd
@@ -9,7 +9,7 @@ from primitiv._device cimport CppDevice
 from primitiv._initializer cimport CppInitializer, Initializer
 
 
-cdef extern from "primitiv/parameter.h":
+cdef extern from "primitiv/core/parameter.h":
     cdef cppclass CppParameter "primitiv::Parameter":
         CppParameter() except +
         CppParameter(const CppShape &shape, const vector[float] &value, CppDevice *device) except +

--- a/primitiv/_shape.pxd
+++ b/primitiv/_shape.pxd
@@ -3,7 +3,7 @@ from libcpp.string cimport string
 from libcpp cimport bool
 
 
-cdef extern from "primitiv/shape.h":
+cdef extern from "primitiv/core/shape.h":
     cdef cppclass CppShape "primitiv::Shape":
         CppShape() except +
         CppShape(vector[unsigned] &dims, unsigned batch) except +

--- a/primitiv/_tensor.pxd
+++ b/primitiv/_tensor.pxd
@@ -5,7 +5,7 @@ from primitiv._device cimport CppDevice
 from primitiv._shape cimport CppShape
 
 
-cdef extern from "primitiv/tensor.h" nogil:
+cdef extern from "primitiv/core/tensor.h" nogil:
     cdef cppclass CppTensor "primitiv::Tensor":
         CppTensor(CppTensor &&src) except +
         CppTensor() except +

--- a/primitiv/devices/_cuda_device.pxd
+++ b/primitiv/devices/_cuda_device.pxd
@@ -1,7 +1,7 @@
 from primitiv._device cimport CppDevice, Device
 
 
-cdef extern from "primitiv/cuda_device.h":
+cdef extern from "primitiv/devices/cuda/device.h":
     cdef cppclass CppCUDA "primitiv::devices::CUDA" (CppDevice):
         CppCUDA(unsigned device_id) except +
         CppCUDA(unsigned device_id, unsigned rng_seed) except +

--- a/primitiv/devices/_eigen_device.pxd
+++ b/primitiv/devices/_eigen_device.pxd
@@ -1,7 +1,7 @@
 from primitiv._device cimport CppDevice, Device
 
 
-cdef extern from "primitiv/eigen_device.h":
+cdef extern from "primitiv/devices/eigen/device.h":
     cdef cppclass CppEigen "primitiv::devices::Eigen" (CppDevice):
         CppEigen() except +
         CppEigen(unsigned rng_seed) except +

--- a/primitiv/devices/_naive_device.pxd
+++ b/primitiv/devices/_naive_device.pxd
@@ -1,7 +1,7 @@
 from primitiv._device cimport CppDevice, Device
 
 
-cdef extern from "primitiv/naive_device.h":
+cdef extern from "primitiv/devices/naive/device.h":
     cdef cppclass CppNaive "primitiv::devices::Naive" (CppDevice):
         CppNaive() except +
         CppNaive(unsigned rng_seed) except +

--- a/primitiv/devices/_opencl_device.pxd
+++ b/primitiv/devices/_opencl_device.pxd
@@ -1,7 +1,7 @@
 from primitiv._device cimport CppDevice, Device
 
 
-cdef extern from "primitiv/opencl_device.h":
+cdef extern from "primitiv/devices/opencl/device.h":
     cdef cppclass CppOpenCL "primitiv::devices::OpenCL" (CppDevice):
         CppOpenCL(unsigned platform_id, unsigned device_id) except +
         CppOpenCL(unsigned platform_id, unsigned device_id, unsigned rng_seed) except +

--- a/primitiv/initializers/_initializer_impl.pxd
+++ b/primitiv/initializers/_initializer_impl.pxd
@@ -1,7 +1,7 @@
 from primitiv._initializer cimport CppInitializer, Initializer
 
 
-cdef extern from "primitiv/initializer_impl.h":
+cdef extern from "primitiv/core/initializer_impl.h":
     cdef cppclass CppConstant "primitiv::initializers::Constant" (CppInitializer):
         CppConstant(float k)
 

--- a/primitiv/optimizers/_optimizer_impl.pxd
+++ b/primitiv/optimizers/_optimizer_impl.pxd
@@ -5,7 +5,7 @@ from primitiv._device cimport CppDevice
 from primitiv._optimizer cimport CppOptimizer, Optimizer
 
 
-cdef extern from "primitiv/optimizer_impl.h":
+cdef extern from "primitiv/core/optimizer_impl.h":
     cdef cppclass CppSGD "primitiv::optimizers::SGD" (CppOptimizer):
         CppSGD(float eta)
         float eta()

--- a/primitiv/py_optimizer.h
+++ b/primitiv/py_optimizer.h
@@ -1,7 +1,7 @@
 #ifndef PRIMITIV_PYTHON_PY_OPTIMIZER_H_
 #define PRIMITIV_PYTHON_PY_OPTIMIZER_H_
 
-#include <primitiv/optimizer.h>
+#include <primitiv/core/optimizer.h>
 #include <iostream>
 
 __PYX_EXTERN_C int primitiv_python_optimizer_get_configs(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.11.0
-cython>=0.27
+numpy>=1.16.1
+cython>=0.29.5
 cmake>=0.9.0
 scikit-build>=0.6.1

--- a/setup.py
+++ b/setup.py
@@ -178,7 +178,11 @@ setup_kwargs = {}
 if build_core:
     setup_kwargs["cmake_source_dir"] = SUBMODULE_DIR
     setup_kwargs["cmake_install_dir"] = "./"
-    setup_kwargs["setup_requires"] = ["scikit-build"]
+    setup_kwargs["setup_requires"] = [
+        "cmake>=0.9.0",
+        "cython>=0.29.5",
+        "scikit-build>=0.6.1",
+    ]
     setup_kwargs["cmake_args"] = ["-DPRIMITIV_BUILD_STATIC_LIBRARY=ON"]
     if sys.platform == "darwin":
         # NOTE(vbkaisetsu):
@@ -237,8 +241,7 @@ setup(
         "primitiv.optimizers",
     ],
     install_requires=[
-        "cython",
-        "numpy",
+        "numpy>=1.16.1",
     ],
     **setup_kwargs,
 )


### PR DESCRIPTION
Related to #28

This branch builds `manylinux2010` binary packages, and uploads them to PyPI.

Example results were uploaded to:
https://test.pypi.org/project/primitiv/0.4.0.dev92/

Binary packages only support the Eigen backend. OpenCL and CUDA are not compatible with PEP 571, so users must build it from the source package if they use GPUs. (`--install-option --enable-***` flags automatically choose the source package.)